### PR TITLE
fixed old workflow to use new build stuff

### DIFF
--- a/.github/workflows/cppbuild-master.yml
+++ b/.github/workflows/cppbuild-master.yml
@@ -13,21 +13,31 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        compiler: [llvm, gnu]
 
     steps:
       - uses: actions/checkout@master
         with:
           submodules: true
-      - name: build with cmake
+      - name: llvm build and test
+        if: matrix.compiler == 'llvm'
+        env:
+          CC: clang
+          CXX: clang++
         run: |
-          which clang
-          export CC=clang
-          export CXX=clang++
           mkdir ./cmake-build-debug
           cd cmake-build-debug
           cmake ../
-          make
-      - name: run C++ tests
-        run: |
-          cd ./cmake-build-debug/c_tests/
-          ./test_libczi_c++_extension
+          cmake --build .
+        shell: bash
+      - name: gnu build and test
+        if: matrix.compiler == 'gnu'
+        env:
+          CC: gcc
+          CXX: g++
+          run: |
+            mkdir ./cmake-build-debug
+            cd cmake-build-debug
+            cmake ../
+            cmake --build .
+          shell: bash

--- a/.github/workflows/cppbuild-master.yml
+++ b/.github/workflows/cppbuild-master.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: 0 10 * * 1
+    - cron: 0 18 * * 1
 
 name: C++ Master Build
 jobs:

--- a/.github/workflows/cppbuild.yml
+++ b/.github/workflows/cppbuild.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: pull_request
 name: C++ Build
 jobs:
   cmake-build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pylibczi
-[![C++ Build & Test](https://github.com/AllenCellModeling/pylibczi/workflows/C%2B%2B%20Build%20%26%20Test/badge.svg)](https://github.com/AllenCellModeling/pylibczi/actions)
-[![Python Build & Test](https://github.com/AllenCellModeling/pylibczi/workflows/Python%20Build%2C%20Test%2C%20%26%20Lint/badge.svg)](https://github.com/AllenCellModeling/pylibczi/actions)
+[![C++ Build & Test](https://github.com/AllenCellModeling/pylibczi/workflows/C%2B%2B+Master+Build/badge.svg)](https://github.com/AllenCellModeling/pylibczi/actions)
+[![Python Build & Test](https://github.com/AllenCellModeling/pylibczi/workflows/Python+Master+Build/badge.svg)](https://github.com/AllenCellModeling/pylibczi/actions)
 [![codecov](https://codecov.io/gh/AllenCellModeling/pylibczi/branch/feature/pybind11/graph/badge.svg)](https://codecov.io/gh/AllenCellModeling/pylibczi)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 


### PR DESCRIPTION
When I merged into master it became clear that I only modified the cppbuild.yml and forgot to fix cppbuild-master.yml. I've migrated the changes now.  I also modified it to only build on push. 

Question for @JacksonMaxfield: With the new github action structure how do the main page badges get set. Actually it seems like the badge points to the path for the workflow so if a branch build fails the baster build badge will change to failed too? If this is true how do we fix it?